### PR TITLE
Publish only release variant to Maven Central

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -53,7 +53,7 @@ extends:
                   workingDirectory: $(Build.Repository.LocalPath)
                   options: '-PbuildNumber=$(buildNumber)'
                   jdkVersionOption: $(jdkVersion)
-                  tasks: 'assemble'
+                  tasks: 'assembleRelease'
                   publishJUnitResults: false
                 condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
               - task: Gradle@2
@@ -128,7 +128,7 @@ extends:
                 displayName: 'Copy AAR Files to: $(build.artifactstagingdirectory)'
                 inputs:
                   SourceFolder: '$(Build.Repository.LocalPath)'
-                  Contents: '**/build/outputs/aar/**/*.aar'
+                  Contents: '**/build/outputs/aar/**/release/*.aar'
                   TargetFolder: '$(build.artifactstagingdirectory)'
                   flattenFolders: true
                 condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -128,7 +128,7 @@ extends:
                 displayName: 'Copy AAR Files to: $(build.artifactstagingdirectory)'
                 inputs:
                   SourceFolder: '$(Build.Repository.LocalPath)'
-                  Contents: '**/build/outputs/aar/**/release/*.aar'
+                  Contents: '**/build/outputs/aar/*.aar'
                   TargetFolder: '$(build.artifactstagingdirectory)'
                   flattenFolders: true
                 condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,7 +145,7 @@ tasks.register("separateDocZipped") {
 tasks.register("publishToMavenCentralStaging") {
     description = "Publishes continuity module to local staging directory for ESRP Maven Central publishing"
     group = "publishing"
-    dependsOn("continuity:publishReleaseAndDebugPublicationToMavenCentralStagingRepository")
+    dependsOn("continuity:publishReleasePublicationToMavenCentralStagingRepository")
 }
 
 subprojects {
@@ -153,9 +153,7 @@ subprojects {
         if (plugins.hasPlugin("com.android.library")) {
             extensions.configure<com.android.build.gradle.LibraryExtension> {
                 publishing {
-                    multipleVariants("releaseAndDebug") {
-                        includeBuildTypeValues("debug", "release")
-                    }
+                    singleVariant("release")
                 }
 
                 buildFeatures {

--- a/continuity/build.gradle.kts
+++ b/continuity/build.gradle.kts
@@ -44,7 +44,8 @@ android {
             val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
             val sdkName = rootProject.extra["build_sdkName"] as String
             val version = rootProject.extra["versionName"] as String
-            output.outputFileName = "$sdkName-${project.name}-$version-$name.aar"
+            val suffix = if (name == "release") "" else "-$name"
+            output.outputFileName = "$sdkName-${project.name}-$version$suffix.aar"
         }
     }
 

--- a/crossdeviceextender/build.gradle.kts
+++ b/crossdeviceextender/build.gradle.kts
@@ -56,7 +56,8 @@ android {
             val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
             val sdkName = rootProject.extra["build_sdkName"] as String
             val version = rootProject.extra["versionName"] as String
-            output.outputFileName = "$sdkName-${project.name}-$version-$name.aar"
+            val suffix = if (name == "release") "" else "-$name"
+            output.outputFileName = "$sdkName-${project.name}-$version$suffix.aar"
         }
     }
     kotlinOptions {

--- a/gradle/maven-publish.gradle
+++ b/gradle/maven-publish.gradle
@@ -1,6 +1,11 @@
 apply plugin: "maven-publish"
 apply plugin: "signing"
 
+// Disable Gradle Module Metadata generation (only publish POM)
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
 // Task to generate sources JAR
 tasks.register('sourcesJar', Jar) {
     archiveClassifier.set('sources')
@@ -17,11 +22,11 @@ tasks.register('javadocJar', Jar) {
 afterEvaluate {
     publishing {
         publications {
-            releaseAndDebug(MavenPublication) {
+            release(MavenPublication) {
                 groupId "${rootProject.ext.mavenGroupId}"
                 artifactId "${rootProject.ext.build_sdkName}-${project.name}"
                 version "${rootProject.ext.componentizedSDKVersion}"
-                from(components.releaseAndDebug)
+                from(components.release)
 
                 // Add sources and javadoc JARs
                 artifact(sourcesJar)
@@ -71,6 +76,6 @@ afterEvaluate {
         required { project.hasProperty('signing.keyId') }
 
         // Sign all publications
-        sign publishing.publications.releaseAndDebug
+        sign publishing.publications.release
     }
 }


### PR DESCRIPTION
- Remove debug AAR from Maven Central publication
- Remove Gradle module metadata (.module files)
- Simplify release AAR naming (remove "-release" suffix)