### PR TITLE
 Update Continuity SDK README with Maven Central integration

### DIFF
--- a/continuity/README.md
+++ b/continuity/README.md
@@ -53,17 +53,17 @@ You will receive:
 
 ## Configure Your Android Development Environment
 
-1. Download the `.aar` file from [Windows Cross-Device SDK releases](https://github.com/microsoft/Windows-Cross-Device/releases).
-2. Copy the `.aar` file to your project's `libs` folder (create if it doesn't exist).
-3. Add the following to your app's `build.gradle`:
+[![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.mmx/crossdevicesdk-continuity)](https://central.sonatype.com/artifact/com.microsoft.mmx/crossdevicesdk-continuity)
 
-   ```groovy
-   dependencies {
-       implementation files('libs/crossdevicesdk-continuity-x.x.x-release.aar')
-   }
-   ```
+Add the dependency to your app's `build.gradle`:
 
-4. Sync your project with Gradle files.
+```groovy
+dependencies {
+    implementation("com.microsoft.mmx:crossdevicesdk-continuity:<version>")
+}
+```
+
+Replace `<version>` with the latest version from the badge above.
 
 ---
 

--- a/continuity/README.md
+++ b/continuity/README.md
@@ -1,5 +1,7 @@
 # Continuity SDK
 
+[![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.mmx/crossdevicesdk-continuity)](https://central.sonatype.com/artifact/com.microsoft.mmx/crossdevicesdk-continuity)
+
 Enables Android apps to send app context to the Link to Windows (LTW) app, allowing users to resume activities on their Windows PCs.
 
 ---
@@ -52,8 +54,6 @@ You will receive:
 ---
 
 ## Configure Your Android Development Environment
-
-[![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.mmx/crossdevicesdk-continuity)](https://central.sonatype.com/artifact/com.microsoft.mmx/crossdevicesdk-continuity)
 
 Add the dependency to your app's `build.gradle`:
 


### PR DESCRIPTION
 PR Description

  ## Summary

  - Add Maven Central badge to README
  - Update installation instructions to use Maven Central dependency
  - Remove local AAR integration option (keep Build local AAR section for development)

  ## Changes

  - Added Maven Central version badge at the top of README
  - Simplified dependency configuration to single `implementation` statement
  - Use `<version>` placeholder for flexibility